### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.rbenv-gemsets
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/lib/riif/rails/renderer.rb
+++ b/lib/riif/rails/renderer.rb
@@ -6,7 +6,7 @@ module Riif
         send_data(
           iif_string,
           filename: "#{filename}.iif",
-          type: Mime::IIF,
+          type: Mime[:iif],
           disposition: 'attachment'
         )
       end

--- a/lib/riif/rails/template_handler.rb
+++ b/lib/riif/rails/template_handler.rb
@@ -2,7 +2,7 @@ module Riif
   module Rails
     class TemplateHandler
       cattr_accessor :default_format
-      self.default_format = Mime::IIF
+      self.default_format = Mime[:iif]
 
       def self.call(template)
         <<-RUBY

--- a/riif.gemspec
+++ b/riif.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rails'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-rails'
+  gem.add_development_dependency 'rspec-its'
+  gem.add_development_dependency 'rails-controller-testing'
   gem.add_development_dependency 'awesome_print'
   gem.add_development_dependency 'combustion', '~> 0.3.1'
   gem.add_development_dependency 'fuubar'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,8 @@ Combustion.initialize! :action_controller, :action_view
 require 'rspec/rails'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.expect_with(:rspec) { |c| c.syntax = :should }
+  config.infer_spec_type_from_file_location!
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = 'random'


### PR DESCRIPTION
Specifically, this:

```
DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::IIF` to `Mime[:iif]`
```