### PR TITLE
Fixes #38 - Adds Rails 6 support to template handler

### DIFF
--- a/lib/riif/rails/template_handler.rb
+++ b/lib/riif/rails/template_handler.rb
@@ -4,11 +4,13 @@ module Riif
       cattr_accessor :default_format
       self.default_format = Mime[:iif]
 
-      def self.call(template)
+      def self.call(template, source = nil)
+        source ||= template.source
+
         <<-RUBY
           iif = ::Riif::IIF.new
 
-          #{template.source}
+          #{source}
 
           iif.output
         RUBY


### PR DESCRIPTION
Rails 6 passes source as a second parameter to the template handler - so allow that, while falling back to `template.source`