### PR TITLE
Changes to stop overwriting the official 'rake' executable when installing this gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## NEXT (unreleased)
 
+- Stop shipping a gem that overwrites the 'rake' executable from the official 'rake' gem
+  when installing this gem through Bundler.
+
 ## 0.8.0
 
 - #38 Deprecation warning on Rails 6.0.0.rc1. [@jaredmoody](https://github.com/jaredmoody)

--- a/riif.gemspec
+++ b/riif.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/linjunpop/riif"
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.executables   = []
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 


### PR DESCRIPTION
This gem overwrites the official `rake` executable when it is installed through Bundler. The rake executable from this gem requires Bundler to work and breaks when outside a Bundler project. Besides, your gem should not be overwriting the executables of other gems.

Please consider this pull request or devise your own solution that doesn't install a broken `rake` when this gem is installed through Bundler. 

I have also opened an issue on the Bundler tracker asking to do the same as rubygems by showing a confirmation prompt in case a gem like this one overwrites the executable from another gem.