### PR TITLE
Resolve potential Ruby csv warning for Ruby 3.4

### DIFF
--- a/riif.gemspec
+++ b/riif.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'combustion', '~> 1.1'
   gem.add_development_dependency 'fuubar'
   gem.add_development_dependency 'coveralls'
+  gem.add_dependency 'csv'
 end


### PR DESCRIPTION
Received the following message when using this gem:

```
warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec.
```

Likely due to CSV being required in `lib/riif/iif.rb` or another of the dependencies of this gem (ActiveSupport?) requiring it. 

